### PR TITLE
Update io.github.zyedidia.micro.yml

### DIFF
--- a/io.github.zyedidia.micro.yml
+++ b/io.github.zyedidia.micro.yml
@@ -1,6 +1,6 @@
 app-id: io.github.zyedidia.micro
 
-runtime: org.freedesktop.Sdk
+runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:


### PR DESCRIPTION
change release version to use org.freedesktop.Platform. In my limited testing, micro remains fully functional with this modification.